### PR TITLE
Added ability to access properties of arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function(selector, obj) {
 			for (var k in obj) {
 				res = res.concat(findRecursive(selector.slice(1), obj[k]));
 			}
-		} else if (Array.isArray(obj)) { // if object is array, check each value, but don't consume selector
+		} else if (Array.isArray(obj) && !obj.hasOwnProperty(selector[0])) { // if object is array, check each value, but don't consume selector
 			for (var i in obj) {
 				res = res.concat(findRecursive(selector, obj[i]));
 			}

--- a/test/finder_test.js
+++ b/test/finder_test.js
@@ -14,7 +14,8 @@ var TEST_OBJ = {
 	"string_array": [ "hello", "world" ],
 	"object_array": [
 		{
-			"key": "value"
+			"key": "value",
+			"0": "zerovalue"
 		},
 		{
 			"key": "value"
@@ -109,7 +110,7 @@ exports['test selectors'] = {
 	},
 	"find child array property": function(test) {
 		var res = finder('object_array.key', TEST_OBJ);
-		
+
 		for (var i in res) {
 			test.equal(res[i], 'value');
 		}
@@ -118,7 +119,7 @@ exports['test selectors'] = {
 	},
 	"find all": function(test) {
 		var res = finder('object_key.*', TEST_OBJ);
-		
+
 		test.equal(res[0], TEST_OBJ.object_key['first_key']);
 		test.equal(res[1], TEST_OBJ.object_key['second_key']);
 
@@ -143,6 +144,20 @@ exports['test selectors'] = {
 		var res = finder('dummy.first.name.too.long.selector', TEST_OBJ);
 
 		test.equal(res.length, 0, "should be empty array");
+
+		test.done();
+	},
+	"find array own properties": function(test) {
+		var res = finder('object_array.length', TEST_OBJ);
+
+		test.equal(res[0], 3, "should have length of 3");
+
+		test.done();
+	},
+	"find array items at index": function(test) {
+		var res = finder('object_array.0.0', TEST_OBJ);
+
+		test.equal(res[0], "zerovalue", "should access value at index");
 
 		test.done();
 	}


### PR DESCRIPTION
Queries to access the length of an array, or items at a specific index are not currently possible.  This simple change gives queries the ability to access array properties if the property exists.
